### PR TITLE
Add support for CNL v1.02

### DIFF
--- a/Common/DtaDev.h
+++ b/Common/DtaDev.h
@@ -292,9 +292,10 @@ public:
 	* @param lockingrange the locking range number to activate in SUM
 	* @param password password of the admin sp SID authority
 	*/
-	virtual uint8_t activateLockingSP_SUM(const uint8_t lockingrange, const char* password,
-                                          const uint32_t dsCount = 0,
-                                          const uint32_t dsSizes[] = NULL) = 0;
+	virtual uint8_t activateLockingSP_SUM(const std::vector<uint32_t>& ranges, const uint32_t policy,
+					      const char* password,
+                                              const uint32_t dsCount = 0,
+                                              const uint32_t dsSizes[] = NULL) = 0;
 	/** Erase a Single User Mode locking range by calling the drive's erase method
 	 * @param lockingrange The Locking Range to erase
 	 * @param password The administrator password for the drive
@@ -335,7 +336,7 @@ public:
 	 * @param length - N/A if global is true
 	 */
 	virtual uint8_t assign(const char* authority, const char* password, const uint32_t ns,
-	                       const uint64_t start = 0, const uint64_t length = 0) = 0;
+	                       const uint64_t start = 0, const uint64_t length = 0, const uint32_t sum = 0) = 0;
 
 	/** Deassign a locking range
 	 * @param authority authority to use for the session

--- a/Common/DtaDevEnterprise.cpp
+++ b/Common/DtaDevEnterprise.cpp
@@ -1018,8 +1018,9 @@ uint8_t DtaDevEnterprise::activateLockingSP(const char* password, const uint32_t
 	LOG(D1) << "Exiting DtaDevEnterprise::activatLockingSP()";
 	return DTAERROR_INVALID_PARAMETER;
 }
-uint8_t DtaDevEnterprise::activateLockingSP_SUM(const uint8_t lockingrange, const char* password,
-                                                const uint32_t dsCount, const uint32_t dsSizes[])
+uint8_t DtaDevEnterprise::activateLockingSP_SUM(const std::vector<uint32_t>& ranges, const uint32_t policy, 
+												const char* password, const uint32_t dsCount,
+												const uint32_t dsSizes[])
 {
 	LOG(D1) << "Entering DtaDevEnterprise::activateLockingSP_SUM()";
 	if (password == NULL) { LOG(D4) << "Referencing formal parameters "; }
@@ -1520,7 +1521,7 @@ uint8_t DtaDevEnterprise::properties()
 }
 
 uint8_t DtaDevEnterprise::assign(const char* authority, const char* password, const uint32_t ns,
-                                 const uint64_t start, const uint64_t length)
+                                 const uint64_t start, const uint64_t length, const uint32_t sum)
 {
     cout << "TCG Enterprise SSC does not include the assign method.\n";
     return 0xff;

--- a/Common/DtaDevEnterprise.h
+++ b/Common/DtaDevEnterprise.h
@@ -74,8 +74,9 @@ public:
 	uint8_t activateLockingSP(const char* password, const uint32_t dsCount = 0,
                               const uint32_t dsSizes[] = NULL);
 	/** dummy code not implemented in teh enterprise SSC*/
-	uint8_t activateLockingSP_SUM(const uint8_t lockingrange, const char* password,
-                                  const uint32_t dsCount = 0, const uint32_t dsSizes[] = NULL);
+	uint8_t activateLockingSP_SUM(const std::vector<uint32_t>& ranges, const uint32_t policy,
+				      const char* password, const uint32_t dsCount = 0,
+				      const uint32_t dsSizes[] = NULL);
 	/** dummy code not implemented in teh enterprise SSC*/
 	uint8_t eraseLockingRange_SUM(const uint8_t lockingrange, const char* password);
         /** dummy code not implemented in teh enterprise SSC*/
@@ -195,7 +196,7 @@ public:
 
 	// virtual methods from DtaDev class
 	uint8_t assign(const char* authority, const char* password, const uint32_t ns,
-                   const uint64_t start = 0, const uint64_t length = 0);
+                   const uint64_t start = 0, const uint64_t length = 0, const uint32_t sum = 0);
 	uint8_t deassign(const char* authority, const char* password, const uint8_t lockingrange,
                      const bool keep);
     uint8_t printTables(const char* sp, const char* password, const uint8_t level);

--- a/Common/DtaDevGeneric.cpp
+++ b/Common/DtaDevGeneric.cpp
@@ -93,15 +93,15 @@ uint8NOCODE(eraseLockingRange, const uint8_t lockingrange, const char* password)
 uint8NOCODE(printDefaultPassword);
 uint8NOCODE(loadPBA, const char* password, const char* filename)
 uint8NOCODE(activateLockingSP, const char* password, const uint32_t dsCount, const uint32_t dsSizes[])
-uint8NOCODE(activateLockingSP_SUM, const uint8_t lockingrange, const char* password, const uint32_t dsCount,
-            const uint32_t dsSizes[])
+uint8NOCODE(activateLockingSP_SUM, const std::vector<uint32_t>& ranges, const uint32_t policy, const char* password,
+            const uint32_t dsCount, const uint32_t dsSizes[])
 uint8NOCODE(eraseLockingRange_SUM, const uint8_t lockingrange, const char* password)
 uint8NOCODE(takeOwnership, const char* newpassword)
 uint8NOCODE(setSIDPassword, const char* oldpassword, const char* newpassword,
             const uint8_t hasholdpwd, const uint8_t hashnewpwd)
 uint8NOCODE(printTables, const char* sp, const char* password, const uint8_t level)
 uint8NOCODE(assign, const char* authority, const char* password, const uint32_t ns, const uint64_t start,
-            const uint64_t length)
+            const uint64_t length, const uint32_t sum)
 uint8NOCODE(deassign, const char* authority, const char* password, const uint8_t lockingrange, const bool keep)
 uint8NOCODE(readMBR, const char* password, const uint32_t offset, const uint32_t count)
 uint8NOCODE(loadDataStore, const char* password, const uint8_t table, const uint32_t offset,

--- a/Common/DtaDevGeneric.h
+++ b/Common/DtaDevGeneric.h
@@ -184,7 +184,8 @@ public:
 	 * @param lockingrange locking range to activate in SUM
 	 * @param password password of the admin sp SID authority
 	 */
-	 uint8_t activateLockingSP_SUM(const uint8_t lockingrange, const char* password,
+	 uint8_t activateLockingSP_SUM(const std::vector<uint32_t>& ranges, const uint32_t policy,
+                                   const char* password,
                                    const uint32_t dsCount = 0, const uint32_t dsSizes[] = NULL);
 	/** Erase a Single User Mode locking range by calling the drive's erase method
          * @param lockingrange The Locking Range to erase
@@ -250,7 +251,7 @@ public:
 
      // virtual methods from DtaDev class
      uint8_t assign(const char* authority, const char* password, const uint32_t ns,
-                    const uint64_t start = 0, const uint64_t length = 0);
+                    const uint64_t start = 0, const uint64_t length = 0, const uint32_t sum = 0);
      uint8_t deassign(const char* authority, const char* password, const uint8_t lockingrange,
                       const bool keep);
      uint8_t readMBR(const char* password, const uint32_t offset, const uint32_t count);

--- a/Common/DtaDevOpal.h
+++ b/Common/DtaDevOpal.h
@@ -89,7 +89,7 @@ public:
          * @param startcol the starting column of data requested
          * @param endcol the ending column of the data requested
          */
-	uint8_t getTable(const std::vector<uint8_t>& table, const uint16_t startcol, const uint16_t endcol);
+	uint8_t getTable(const std::vector<uint8_t>& table, const uint32_t startcol, const uint32_t endcol);
          /** Set the SID password.
          * Requires special handling because password is not always hashed.
          * @param oldpassword  current SID password
@@ -124,8 +124,9 @@ public:
          * @param lockingrange  the locking range number to activate in SUM
          * @param password  current SID password
          */
-	uint8_t activateLockingSP_SUM(const uint8_t lockingrange, const char* password,
-								  const uint32_t dsCount = 0, const uint32_t dsSizes[] = NULL);
+	uint8_t activateLockingSP_SUM(const std::vector<uint32_t>& ranges, const uint32_t policy,
+	                              const char* password, const uint32_t dsCount = 0,
+	                              const uint32_t dsSizes[] = NULL);
 	/** Erase a Single User Mode locking range by calling the drive's erase method
          * @param lockingrange The Locking Range to erase
          * @param password The administrator password for the drive
@@ -312,7 +313,7 @@ public:
 
 	// virtual methods from DtaDev class
 	uint8_t assign(const char* authority, const char* password, const uint32_t ns,
-				   const uint64_t start = 0, const uint64_t length = 0);
+				   const uint64_t start = 0, const uint64_t length = 0, const uint32_t sum = 0);
 	uint8_t deassign(const char* authority, const char* password, const uint8_t lockingrange,
 					 const bool keep);
 	uint8_t readMBR(const char* password, const uint32_t offset, const uint32_t count);

--- a/Common/DtaOptions.cpp
+++ b/Common/DtaOptions.cpp
@@ -336,8 +336,10 @@ uint8_t DtaOptions(int argc, char * argv[], DTA_OPTIONS * opts)
 		BEGIN_OPTION(enableuser, 3) OPTION_IS(password) OPTION_IS(userid)
 			OPTION_IS(device) END_OPTION
 		BEGIN_OPTION(activateLockingSP, 2) OPTION_IS(password) OPTION_IS(device) END_OPTION
-		BEGIN_OPTION(activateLockingSP_SUM, 3)
-			TESTARG_RANGE(lockingrange, 0, 255, "Invalid Locking Range (0-47 or 255 for all)")
+		BEGIN_OPTION(activateLockingSP_SUM, 4)
+//			TESTARG_RANGE(lockingrange, 0, 255, "Invalid Locking Range (0-47 or 255 for all)")
+                        OPTION_IS(lockingrange)
+                        TESTARG_RANGE(policy, 0, 1, "Invalid policy (0-1)")
 			OPTION_IS(password) OPTION_IS(device) END_OPTION
 		BEGIN_OPTION(eraseLockingRange_SUM, 3)
 			TESTARG_RANGE(lockingrange, 0, 47, "Invalid Locking Range (0-47)")
@@ -496,6 +498,13 @@ uint8_t DtaOptions(int argc, char * argv[], DTA_OPTIONS * opts)
             TESTARG(f, lockingstate, 0)
             TESTARG(F, lockingstate, 0)
             TESTFAIL("Invalid value for keep argument (T or F)")
+            OPTION_IS(password)
+            OPTION_IS(device)
+            END_OPTION
+        BEGIN_OPTION(assign_SUM, 5)
+            OPTION_IS(lockingrange)
+            OPTION_IS(lrstart)
+            OPTION_IS(lrlength)
             OPTION_IS(password)
             OPTION_IS(device)
             END_OPTION

--- a/Common/DtaOptions.h
+++ b/Common/DtaOptions.h
@@ -50,6 +50,7 @@ typedef struct _DTA_OPTIONS {
 	uint8_t level;			/** output level, for print operations */
 	uint8_t offset;			/** offset in table */
 	uint8_t count;			/** Count of bytes in table */
+        uint8_t policy;                 /** RangeStartLengthPolicy (activate SUM) */
     uint8_t spindex;        /**< index to sp var */
     uint8_t testTimeout;
     uint8_t testOversizePacket;
@@ -121,8 +122,9 @@ typedef enum _sedutiloption {
 	isValidSED,
     eraseLockingRange,
 	takeOwnership,
-	assign,
-	deassign,
+    assign,
+    assign_SUM,
+    deassign,
 	validatePBKDF2,
 	objDump,
     printDefaultPassword,
@@ -165,7 +167,8 @@ if((x+baseOptions) != argc) { \
 
 #define TESTARG_RANGE(structfield, minValue, maxValue, errorStr) \
     opts->structfield = static_cast<uint8_t>(atoi(argv[i + 1])); \
-    if ((opts->structfield < minValue) || (opts->structfield > maxValue)) \
+    if ((opts->structfield < minValue) || (opts->structfield > maxValue) || \
+       ((opts->structfield == 0) && (argv[i + 1][0] != '0'))) \
     TESTFAIL(errorStr)
 
 /** set the argc value for this parameter in the options structure */

--- a/Common/DtaStructures.h
+++ b/Common/DtaStructures.h
@@ -255,8 +255,8 @@ typedef struct _Discovery0DatastoreTable {
  */
 typedef struct _Discovery0OPALV200 {
     uint16_t featureCode; /* 0x0203 */
-    uint8_t reserved_v : 4;
-    uint8_t version : 4;
+    uint8_t minorVersion : 4;
+    uint8_t version      : 4;
     uint8_t length;
     uint16_t baseCommID;
     uint16_t numCommIDs;
@@ -310,8 +310,8 @@ typedef struct _Discovery0BlockSID {
  */
 typedef struct _Discovery0CNL {
     uint16_t featureCode; /* 0x0403 */
-    uint8_t reserved_v : 4;
-    uint8_t version : 4;
+    uint8_t minor_version : 4;
+    uint8_t version       : 4;
     uint8_t length;
 
     /* big endian
@@ -319,7 +319,8 @@ typedef struct _Discovery0CNL {
     uint8_t range_P : 1;
     uint8_t reserved04 : 6;
      */
-    uint8_t reserved04 : 6;
+    uint8_t reserved04 : 5;
+    uint8_t sum_C      : 1;
     uint8_t range_P    : 1;
     uint8_t range_C    : 1;
 
@@ -543,6 +544,8 @@ typedef struct _OPAL_DiskInfo {
 	uint16_t OPAL10_basecomID;
 	uint16_t OPAL10_numcomIDs;
     uint8_t OPAL10_rangeCrossing;
+    uint8_t OPAL20_version      : 4;
+    uint8_t OPAL20_minorVersion : 4;
     uint16_t OPAL20_basecomID;
     uint16_t OPAL20_numcomIDs;
     uint8_t OPAL20_initialPIN;
@@ -555,8 +558,11 @@ typedef struct _OPAL_DiskInfo {
     uint8_t BlockSID_lockingSPFreezeSup : 1;
     uint8_t BlockSID_lockingSPFreezeState : 1;
     uint8_t BlockSID_hardwareReset : 1;
+    uint8_t CNL_version      : 4;
+    uint8_t CNL_minorVersion : 4;
     uint8_t CNL_rangeC : 1;
     uint8_t CNL_rangeP : 1;
+    uint8_t CNL_sumC   : 1;
     uint32_t CNL_maxKeyCount;
     uint32_t CNL_unusedKeyCount;
     uint32_t CNL_maxRangesPerNS;

--- a/docs/sedutil-cli.8
+++ b/docs/sedutil-cli.8
@@ -132,8 +132,9 @@ Get a random number of <size> bytes.  Default SP is Admin, over-ride with -sp op
 .IP "\-\-setup_SUM <0...n> <lrstart> <lrlength> <password> <newpassword> <device>"
 Initial setup for the device in TCG Opal Single User Mode.  Selects Global range (0) or a single range (1..n).  
 lrstart and lrlength are ignored got global range. password in the SID password, User<n+1> password will be set to newpassword.
-.IP "\-\-activateLockingSP_SUM <0...n> <SIDpassword> <device>"
-Activate the LockingSP in Single User Mode on Global range (0), a single range (1..n), or all ranges (255).
+.IP "\-\-activateLockingSP_SUM <x,y,z> <policy> <SIDpassword> <device>"
+Activate the LockingSP in Single User Mode on all ranges (-1) or a comma separated list of ranges (0,4,8,10).
+policy is the RangeStartLengthPolicy, 0 for User, 1 for Admin.
 Admin1 password in LockingSP will be set to SID password.
 .IP "\-\-setPassword_SUM <password> <user> <newpassword> <device>"
 Change the password of a TCG Opal User authority. user = User1, User2, ...  Default User passwords are "".
@@ -145,6 +146,8 @@ Set the locking status of a Locking Range, 0 = GLobal 1..n = LRn.  password is f
 Setup a new Locking Range, 0 = GLobal 1..n = LRn.  password is for the User<n> that owns the Locking Range.
 .IP "\-\-enableLockingRange_SUM <0...n> <RW|R|W|D> <password> <device>"
 Set the ReadLockEnable and WriteLockEnable state for a LockingRange, 0 = Global, 1..n = LRn.  password is for the User<n> that owns the Locking Range
+.IP "\-\-assign_SUM <Admin1Password> <namespace> <rangeStart> <rangeLength> <device>"
+Assign a locking range for a namespace (CNL feature) using AssignToSUMRange option.  Default authority is Admin1, over-ride with -a option.
 
 .SS TCG Enterprise devices only 
 .IP "\-\-setBandsEnabled <password> <device>"


### PR DESCRIPTION
Several changes to support and test CNL v1.02.
1. Add SUM_C to query output.  Fixed the discovery0 len calculation.
2. Add assign_SUM action to create an assign method call with the AssignToSUMRange argument true.  
3. Modify activateLockingSP_SUM to change the lockingrange argument to allow a list.  Also added a policy argument.
4. Modified listLockingRanges to use a single Get and then parse all of the columns before printing.  This avoids crashing in SUM.
5. Added code io listLockingRanges to retrieve the SUM column from Locking Info table and print it after the ranges, but then I realized that there is no ACE defined to allow this column to be read, so I commented it out.