### PR TITLE
Add -ftabstop=4 compiler option

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,6 +1,6 @@
 AUTOMAKE_OPTIONS = foreign subdir-objects
-AM_CFLAGS = -Wall -Werror -std=c11
-AM_CXXFLAGS = -Wall -Werror -std=c++11 -I./Common -I./Common/pbkdf2 -I./linux -I./LinuxPBA
+AM_CFLAGS = -Wall -Werror -std=c11 -ftabstop=4
+AM_CXXFLAGS = -Wall -Werror -std=c++11 -ftabstop=4 -I./Common -I./Common/pbkdf2 -I./linux -I./LinuxPBA
 SEDUTIL_COMMON_CODE = \
 	Common/DtaAnnotatedDump.cpp Common/DtaAnnotatedDump.h \
 	Common/DtaCommand.cpp Common/DtaCommand.h \


### PR DESCRIPTION
Add compiler option to set tabs to 4 spaces to avoid compiler error "note: ...this statement, but the latter is misleadingly indented as if it were guarded by the ‘else’" from the mixed spaces and tabs in DtaOptions.c and DtaOptions.h.