### PR TITLE
Add -mt (multi-thread) option

### DIFF
--- a/Common/DtaDev.cpp
+++ b/Common/DtaDev.cpp
@@ -638,7 +638,7 @@ void DtaDev::printSecurityCompliance()
     uint8_t lastRC;
     if ((lastRC = sendCmd(IF_RECV, 0x00, SFSC_SECURITY_COMPLIANCE_INFO, bufferPtr, DTA_DEV_BUFFER_SIZE)) != 0) {
         LOG(D2) << "Send security compliance request to device failed " << (uint16_t)lastRC;
-        cout << "Failed to retrieve FIPS-140 compliance page from the device" << std::endl;
+        cout << "Failed to retrieve FIPS 140 compliance page from the device" << std::endl;
         return;
     }
 
@@ -661,7 +661,7 @@ void DtaDev::printSecurityCompliance()
             return;
         }
 
-        cout << "SFSC FIP-140 Compliance Descriptor:" << std::endl;
+        cout << "SFSC FIPS 140 Compliance Descriptor:" << std::endl;
         cout << "Related Standard: " << HEXON(2) << (int)(descPtr->FIPS140_ReleastedStandard) << HEXOFF <<
             (descPtr->FIPS140_ReleastedStandard == FIPS_140_2 ? " (FIPS 140-2)" :
                 descPtr->FIPS140_ReleastedStandard == FIPS_140_3 ? " (FIPS 140-3)" : " (Unknown)")

--- a/Common/DtaDev.h
+++ b/Common/DtaDev.h
@@ -434,6 +434,7 @@ public:
 	sedutiloutput output_format; /** standard, readable, JSON */
     uint32_t timeout = 0;   /** Session timeout, 0 is no timeout */
     uint32_t delay = 0;     /** Delay between open session and first method call */
+    uint32_t sendRetries = 0;
     bool testTimeout = false;
     bool testOversizePacket = false;
     bool useTransaction = false;

--- a/Common/DtaOptions.cpp
+++ b/Common/DtaOptions.cpp
@@ -284,6 +284,11 @@ uint8_t DtaOptions(int argc, char * argv[], DTA_OPTIONS * opts)
                 }
             }
         }
+        else if (!strncmp("-mt=", argv[i], 4)) {
+            ++baseOptions;
+            opts->sendRetries = atoi(&argv[i][4]);
+            LOG(D) << "multi-thread retry count set to " << opts->sendRetries;
+        }
         else if (!(('-' == argv[i][0]) && ('-' == argv[i][1])) && (0 == opts->action)) {
 			LOG(E) << "Argument " << (uint16_t) i << " (" << argv[i] << ") should be a command";
 			return DTAERROR_INVALID_COMMAND;

--- a/Common/DtaOptions.h
+++ b/Common/DtaOptions.h
@@ -66,6 +66,7 @@ typedef struct _DTA_OPTIONS {
     char    sp[16];         /** security protocol */
     uint32_t timeout;       /** session timeout option */
     uint32_t delay;         /** delay between open session and first method call */
+    uint32_t sendRetries;
     uint32_t datastoreCount;
     uint32_t datastoreSizes[16];
 	sedutiloutput output_format;

--- a/Common/sedutil.cpp
+++ b/Common/sedutil.cpp
@@ -112,12 +112,13 @@ int main(int argc, char * argv[])
         d->testOversizePacket = opts.testOversizePacket;
         d->useTransaction     = opts.useTransaction;
         d->useReadOnlySession = opts.useReadOnlySession;
+        d->sendRetries        = opts.sendRetries;
     }
 
     char* end;
 
     switch (opts.action) {
- 	case sedutiloption::initialSetup:
+	case sedutiloption::initialSetup:
 		LOG(D) << "Performing initial setup to use sedutil on drive " << argv[opts.device];
         return (d->initialSetup(argv[opts.password]));
 	case sedutiloption::setup_SUM:


### PR DESCRIPTION
Add the -mt option to support multi-threading.  The format is:
-mt=x 
where x is the number of retries to perform on a Security Send command that returns a transport error (i.e., NVMe Command Sequence Error) before returning an error status to the caller.  There is a delay between retries.

The purpose of this option is to allow multiple instances of sedutil-cli to run concurrently sharing a comID.  When this happens, it is possible that one instance will have sent a Security Send command and not yet sent a Security Receive command when another instance sends a Security Send command.  If this happens, the second instance will receive a Command Sequence Error.  Rather than fail, the -mt option will allow that instance to delay and then try again.

This is an option useful for testing but not really for common usage, so this option in not documented in the man or help page.