### PR TITLE
Add -o option

### DIFF
--- a/Common/DtaDev.cpp
+++ b/Common/DtaDev.cpp
@@ -49,6 +49,7 @@ DtaDev::DtaDev() :
 
 DtaDev::~DtaDev()
 {
+    CloseOutputFile();
 }
 
 uint8_t DtaDev::isRuby1() const
@@ -689,4 +690,36 @@ void DtaDev::printSecurityCompliance()
         return;
     }
     cout << "FIPS descriptor not found" << std::endl;
+}
+
+void DtaDev::OpenOutputFile()
+{
+    if (outputFileName != NULL) {
+         outputStream.open(outputFileName, std::ios::binary | std::ios::out);
+         if (!outputStream.is_open()) {
+             cout << "Error opening output file " << outputFileName << std::endl;
+         }
+    }
+}
+
+void DtaDev::CloseOutputFile()
+{
+    if (outputStream.is_open()) {
+        outputStream.close();
+    }
+}
+
+void DtaDev::SendToOutputFile(const uint8_t* data, const int count)
+{
+    if (!outputStream.is_open()) {
+        OpenOutputFile();
+    }
+
+    if (outputStream.is_open()) {
+        outputStream.write((const char*)data, count);
+        outputStream.flush();
+//        cout << "Write " << count << " bytes to file " << outputFileName << std::endl;
+    } else {
+        cout << "SendToOutputFile: outputStream failed to open\n";
+    }
 }

--- a/Common/DtaDev.h
+++ b/Common/DtaDev.h
@@ -23,6 +23,7 @@ along with sedutil.  If not, see <http://www.gnu.org/licenses/>.
 #include <vector>
 #include "DtaOptions.h"
 #include "DtaResponse.h"
+#include <fstream>
 
 #ifndef MIN
 #define MIN(a,b) (((a)<(b))?(a):(b))
@@ -465,6 +466,10 @@ public:
 
     void GetExtendedComID(uint16_t* ComID, uint16_t* ComIDExtension);
 
+    void OpenOutputFile();
+    void CloseOutputFile();
+    void SendToOutputFile(const uint8_t* data, const int count);
+
 	bool no_hash_passwords; /** disables hashing of passwords */
 	sedutiloutput output_format; /** standard, readable, JSON */
     uint32_t timeout = 0;   /** Session timeout, 0 is no timeout */
@@ -478,6 +483,8 @@ public:
     uint16_t ComIDValue = 0;
     uint16_t ComIDExtentionValue = 0;
     ComIDOption_t ComIDOption = ComID_Base;
+    char * outputFileName = NULL;
+    std::ofstream outputStream;
 
 protected:
 	const char * dev;   /**< character string representing the device in the OS lexicon */

--- a/Common/DtaDevOpal.cpp
+++ b/Common/DtaDevOpal.cpp
@@ -1793,7 +1793,11 @@ uint8_t DtaDevOpal::readMBR(const char* password, const uint32_t offset, const u
             break;
         }
 
-        DtaHexDump(buffer, chunkSize);
+        if (outputFileName == NULL) {
+            DtaHexDump(buffer, chunkSize);
+        } else {
+            SendToOutputFile(buffer, chunkSize);
+        }
     }
 
     delete session;
@@ -2000,7 +2004,11 @@ uint8_t DtaDevOpal::readDataStore(const char* password, const uint8_t table, con
             break;
         }
 
-        DtaHexDump(buffer, chunkSize);
+        if (outputFileName == NULL) {
+            DtaHexDump(buffer, chunkSize);
+        } else {
+            SendToOutputFile(buffer, chunkSize);
+        }
     }
 
     delete session;

--- a/Common/DtaOptions.cpp
+++ b/Common/DtaOptions.cpp
@@ -42,6 +42,7 @@ void usage()
     printf("-t=timeout (optional)           specify a session timeout value to be sent with the Start Session\n");
     printf("-ds=x,y,z (optional)            specify datastore sizes for activate\n");
     printf("-sp=sp (optional)               specify a security protocol to access, Admin or Locking\n");
+    printf("-o=output_file                  specify the results be sent to a file (readDataStore and readMBR only)\n");
     printf("\n");
     printf("actions:\n");
     printf("--scan\n");
@@ -284,6 +285,10 @@ uint8_t DtaOptions(int argc, char * argv[], DTA_OPTIONS * opts)
                     return DTAERROR_INVALID_COMMAND;
                 }
             }
+        }
+        else if (!strncmp("-o=", argv[i], 3)) {
+          ++baseOptions;
+          opts->outputFilePtr = argv[i] + 3;
         }
         else if (!strncmp("-mt=", argv[i], 4)) {
             ++baseOptions;

--- a/Common/DtaOptions.h
+++ b/Common/DtaOptions.h
@@ -71,6 +71,7 @@ typedef struct _DTA_OPTIONS {
     uint32_t sendRetries;
     uint32_t datastoreCount;
     uint32_t datastoreSizes[16];
+    char *   outputFilePtr;
 	sedutiloutput output_format;
 } DTA_OPTIONS;
 

--- a/Common/sedutil.cpp
+++ b/Common/sedutil.cpp
@@ -114,6 +114,7 @@ int main(int argc, char * argv[])
         d->useReadOnlySession = opts.useReadOnlySession;
         d->useSessionTimeout  = opts.useSessionTimeout;
         d->sendRetries        = opts.sendRetries;
+        d->outputFileName     = opts.outputFilePtr;
     }
 
     char* end;

--- a/docs/sedutil-cli.8
+++ b/docs/sedutil-cli.8
@@ -39,6 +39,8 @@ over-ride the default authority. authority options are Admin<1..n>, User<1..n>, 
 specify a security protocol to access, Admin or Locking.  This option is not supported by all actions.
 .IP "\-ds=x,y,z (optional)"
 optionally used with activate commands. Set the Datastore tables sizes.  1 to n size values comma separated (no spaces).
+.IP "\-o=output_file (optional)"
+specify the results be sent to a file (readDataStore and readMBR actions only).
 
 .SS Actions
 


### PR DESCRIPTION
Add an new option -o-file_name to use with --readDataStore and --readMBR to put the results directly into a file without any conversion to human readable format.